### PR TITLE
added media query for container.module.css

### DIFF
--- a/components/About/About.module.css
+++ b/components/About/About.module.css
@@ -50,7 +50,7 @@
 
     /* misc */
     box-sizing: border-box;
-    /* box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); */
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
 
 .textbox-about {
@@ -102,9 +102,12 @@
 
 .img-about {
     /* box model */
+    display: flex;
     max-width: 320px;
     padding-right: 10px;
     margin-right: -60px;
+    align-items: flex-start;
+    justify-content: center;
 
     /* visual */
     filter: grayscale(100%);
@@ -116,11 +119,16 @@
     border-radius: 20px;
     width: 100%;
     height: auto;
+    max-width: 280px;
     filter: grayscale(100%);
 }
 
 .inline-img {
     display: none;
+}
+
+.paragraph-with-image {
+    position: relative;
 }
 
 /* large desktop */
@@ -143,18 +151,16 @@
     }
 }
 
-/* small desktop */
-@media (min-width: 768px) and (max-width: 991.98px) {
-    .main-about {
-        padding: 100px 5%;
-    }
-
+/* Medium desktop - 992px to 1199px */
+@media (min-width: 992px) and (max-width: 1199px) {
     .section-interior {
         max-width: 960px;
+        padding: 0 15px;
     }
 
     .layout-about {
         max-width: 960px;
+        gap: 40px;
     }
 
     .textbox-about {
@@ -162,8 +168,61 @@
     }
 }
 
-/* tablet */
-@media (min-width: 575.98px) and (max-width: 767.98px) {
+
+/* Tablet Portrait - 768px to 991px */
+@media (min-width: 768px) and (max-width: 991px) {
+    .main-about {
+        padding: 120px 20px 80px;
+        min-height: auto;
+        height: auto;
+    }
+
+    .section-interior {
+        max-width: 100%;
+        padding: 0 30px;
+        /* margin-top: 40px; */
+    }
+
+    .section-h1 {
+        margin: 0 0 30px 0;
+        padding-top: 40px;
+    }
+
+    .layout-about {
+        grid-template-columns: 2fr 1fr;
+        gap: 30px;
+        padding: 25px;
+        max-width: 100%;
+    }
+
+    .textbox-about {
+        max-width: 100%;
+        padding: 15px;
+    }
+
+    .img-about {
+        max-width: 100%;
+        padding: 30px;
+
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .custom-img {
+        width: 100%;
+        height: auto;
+        max-height: 400px;
+        object-fit: cover;
+    }
+
+    .ul-about {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+/* Tablet Landscape / Small Portrait - 576px to 767px */
+@media (min-width: 576px) and (max-width: 767px) {
     .main-about {
         padding: 100px 5%;
     }
@@ -192,16 +251,16 @@
         padding-right: 0;
     }
 
-    /* .custom-img{
-        width: 100%;
-        height: auto;
-    } */
+    .custom-img {
+        padding-top: 0;
+        max-width: 180px;
+    }
 }
 
-/* phone */
-@media (max-width: 575.98px) {
+/* Phone - max 575px */
+@media (max-width: 575px) {
     .main-about {
-        padding: 40px 5% 20px;
+        padding: 80px 5% 20px;
     }
 
     .section-interior {

--- a/components/Container/Container.module.css
+++ b/components/Container/Container.module.css
@@ -73,6 +73,25 @@
   }
 }
 
+/* Tablet (768px - 991px) */
+@media (min-width: 768px) and (max-width: 991px) {
+  .wrapper {
+    /* layout */
+    grid-template-columns: 1fr;
+    grid-template-rows: 100vh auto auto auto auto;
+    grid-template-areas:
+      "landing"
+      "about"
+      "experience"
+      "projects"
+      "footer";
+    
+    /* box model */
+    gap: 10px; /* Stylistic gaps between sections */
+    padding: 0 20px; /* Side padding for left/right gaps */
+  }
+}
+
 /* Phone */
 @media (max-width: 575.98px) {
   .wrapper {

--- a/components/Experience/Experience.module.css
+++ b/components/Experience/Experience.module.css
@@ -22,21 +22,28 @@
 
     /* misc */
     box-sizing: border-box;
+    overflow-x: hidden; /* adding this shows that experince is clipped meanin*/
 }
 
 .section-interior {
+    /* box model */
     margin: 0px auto;
     position: relative;
-    /* max-width: 900px; */
-    /* width: 100%; */
+
+
 }
 
 .layout-experience {
+    /* layout */
     display: grid;
     grid-template-columns: 1fr;
+
+    /* box model */
+    padding: 30px;
     gap: 30px;
     max-width: 900px;
-    padding: 30px;
+
+    /* visual */
     border-radius: 20px;
     background-color: hsla(
         0,
@@ -44,8 +51,8 @@
         100%,
         0.8
     ); /* Increased opacity for better contrast */
-    box-sizing: border-box;
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); /* Added subtle shadow for depth */
+    box-sizing: border-box;
 }
 
 .experience-item {
@@ -116,10 +123,44 @@
     }
 }
 
-/* Tablet */
+/* Tablet (768px - 991px) - MATCHING ABOUT SECTION */
 @media (min-width: 768px) and (max-width: 991px) {
     .main-experience {
-        padding: 100px 5%;
+        /* box model */
+        padding: 100px 20px;
+    }
+
+    .section-interior {
+        /* box model */
+        max-width: 100%;
+        padding: 0 30px;
+    }
+
+    .section-h1 {
+        /* box model */
+        margin: 0 0 30px 0;
+        padding-top: 0;
+    }
+
+    .layout-experience {
+        /* box model */
+        padding: 30px;
+        max-width: 100%;
+    }
+
+    .experience-item {
+        /* box model */
+        padding: 18px;
+    }
+
+    .experience-title {
+        /* typography */
+        font-size: 1.3em;
+    }
+
+    .experience-company {
+        /* typography */
+        font-size: 1.1em;
     }
 }
 


### PR DESCRIPTION
The main issue fixed here was an issue where the Experience section was overlapping with the About section. The issue was that in my container.module.css file there was no media query and defined styles for the grid. When tablet dimensions were activated the styles were not defined so they reverted to the default styles for the container. 

those default styles for the container did not fit well in the tablet view. 